### PR TITLE
Added virtual environments to flask server build via Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,16 @@ FROM python:3.7-alpine
 # set the working director in the container
 WORKDIR /code
 
+# sets the location of the virtual env environment variable
+ENV VIRTUAL_ENV=/opt/venv
+
+# creates virtual environment at location defined by VIRTUAL_ENV environment variable
+RUN python3 -m venv $VIRTUAL_ENV
+
+# adds the virtualenv's bin directory to the start of PATH
+# functionally equivalent to "activating" virtualenv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 # set environment variables
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -8,47 +8,14 @@ To shut down the applications:
 
 `docker-compose down`
 
+If you make changes to the Dockerfile or any other elements of the build config, you may need to rebuild the containers:
+
+`docker-compose build`
+
+Alternatively, you can both build and launch the containers in one command:
+
+`docker-compose up --build`
+
 More information on how to use docker commands can be found on the Docker website: https://docs.docker.com/compose/reference/overview/ 
 
 Note: this containerization is configured for development only. We still need to write some build files for the production build.
-
-## (Deprecated) Set Up: no longer required with Docker containerization ##
-
-Disclaimer: creating a virtual environment is not strictly necessary, but I included it here as a good practice. If you create a virtual machine, it won't affect the rest of your system modules and dependencies. 
-
-```
-python3 -m venv venv
-source venv/bin/activate
-```
-
-Then once you are in the virtual environment (you should see venv prepending all your commands in terminal), enter the following commands:
-
-```
-pip install flask python-dotenv
-pip install -U flask-cors
-```
-
-Then, create your .env file:
-
-```
-touch .env
-```
-
-Open the .env file with your favorite editor and add the following configurations:
-
-```
-FLASK_APP=app.py
-FLASK_ENV=development
-```
-
-## Execution ##
-
-In order to run the web server, you will need two open terminals, one to run the react app and one to run the flask server. The React app is the main app that you interact with as a user, and it makes calls to the Flask server in the backend using the useEffect hook. 
-
-From the root directory, enter the following command:
-
-```flask run```
-
-From react-frontend-app, enter the following command:
-
-```npm start```

--- a/react-frontend-app/Dockerfile
+++ b/react-frontend-app/Dockerfile
@@ -5,7 +5,7 @@ FROM node:12.18.1
 WORKDIR /app
 
 # add `/app/node_modules/.bin` to $PATH
-ENV PATH /app/node_modules/.bin:$PATH
+ENV PATH=/app/node_modules/.bin:$PATH
 
 # install app dependencies
 COPY package.json ./


### PR DESCRIPTION
Modified Dockerfile for flask server to instead activate a virtual environment. Added more docker-compose command instructions to the README and removed deprecated pre-docker documentation.